### PR TITLE
Fix: color picker now opening after first time Issue #31

### DIFF
--- a/ForestBrush/Filtering.cs
+++ b/ForestBrush/Filtering.cs
@@ -19,9 +19,9 @@ namespace ForestBrush
 
     public enum FilterStyle
     {
-        Basic,
         AND,
         OR,
+        Basic
     }
 
     public class Filtering
@@ -144,7 +144,7 @@ namespace ForestBrush
                             if (item == null) continue;
                             string itemTitle = item.GetUncheckedLocalizedTitle().ToLower();
                             bool itemHasData = treeMeshData.TryGetValue(item.name, out TreeMeshData itemData);
-                            bool itemHasAuthor = treeAuthors.TryGetValue(item.name, out string itemAuthor);
+                            bool itemHasAuthor = treeAuthors.TryGetValue(item.name.Split('.')[0], out string itemAuthor);
 
                             bool isTextureMatch = itemHasData && isTextureSizeFilter && textureSize > 0 && (itemData.textureSize.x <= textureSize && itemData.textureSize.y <= textureSize);
                             bool isTrisMatch = isTrisCountFilter && itemHasData && itemData.triangles > 0 && (itemData.triangles <= trisCount);
@@ -173,7 +173,7 @@ namespace ForestBrush
                             {
                                 AddItem(Filter.Author, item);
                             }
-                            if (isStringMatch)
+                            else if (isStringMatch)
                             {
                                 AddItem(Filter.String, item);
                             }
@@ -245,7 +245,7 @@ namespace ForestBrush
                             if (item == null) continue;
                             string itemTitle = item.GetUncheckedLocalizedTitle().ToLower();
                             bool itemHasData = treeMeshData.TryGetValue(item.name, out TreeMeshData itemData);
-                            bool itemHasAuthor = treeAuthors.TryGetValue(item.name, out string itemAuthor);
+                            bool itemHasAuthor = treeAuthors.TryGetValue(item.name.Split('.')[0], out string itemAuthor);
                             if ((textureSizeFilter && itemHasData && textureSize > 0 && (itemData.textureSize.x <= textureSize && itemData.textureSize.y <= textureSize))
                             || (trisCountFilter && itemHasData && itemData.triangles > 0 && (itemData.triangles <= trisCount))
                             || (showNotBrushTree && !brushTrees.Contains(item))

--- a/ForestBrush/GUI/BrushEditSection.cs
+++ b/ForestBrush/GUI/BrushEditSection.cs
@@ -64,7 +64,7 @@ namespace ForestBrush.GUI
             SetupButtons();
             SetupListSection();
             SetupSearchFieldSection();
-            Hide();
+            if(!UserMod.Settings.BrushEditOpen) Hide();
         }
 
         public override void OnDestroy()

--- a/ForestBrush/GUI/BrushOptionsSection.cs
+++ b/ForestBrush/GUI/BrushOptionsSection.cs
@@ -42,7 +42,8 @@ namespace ForestBrush.GUI
             SetupDensityPanel();
             SetupAutoDensityPanel();
             SetupSquareBrushPanel();
-            Hide();
+
+            if(!UserMod.Settings.BrushOptionsOpen) Hide();
         }
 
         public override void OnDestroy()
@@ -221,7 +222,7 @@ namespace ForestBrush.GUI
             densitySlider.atlas = ResourceLoader.Atlas;
             densitySlider.size = new Vector2(400f - densityLabel.width - 30f, 5f);
             densitySlider.color = new Color32(0, 0, 0, 255);
-            densitySlider.disabledColor = new Color32(190, 190, 190, 255);
+            densitySlider.disabledColor = new Color32(75, 75, 75, 255);
             densitySlider.minValue = 0f;
             densitySlider.maxValue = 16f;
             densitySlider.stepSize = 0.1f;
@@ -239,6 +240,7 @@ namespace ForestBrush.GUI
             thumb1.atlas = ResourceLoader.Atlas;
             thumb1.size = new Vector2(20, 20);
             thumb1.spriteName = ResourceLoader.IconPolicyForest;
+            thumb1.disabledColor = new Color32(100, 100, 100, 255);
             densitySlider.thumbObject = thumb1;
         }
 
@@ -377,12 +379,12 @@ namespace ForestBrush.GUI
 
         private void ColorField_eventColorPickerClose(UIColorField colorField, UIColorPicker popup, ref bool overridden)
         {
-            colorField.triggerButton.isInteractive = false;
+            colorField.triggerButton.isInteractive = true;
         }
 
         private void ColorField_eventColorPickerOpen(UIColorField colorField, UIColorPicker popup, ref bool overridden)
         {
-            colorField.triggerButton.isInteractive = true;
+            colorField.triggerButton.isInteractive = false;
         }
 
         private void ColorField_eventSelectedColorChangedHandler(UIComponent component, Color value)

--- a/ForestBrush/GUI/BrushSelectSection.cs
+++ b/ForestBrush/GUI/BrushSelectSection.cs
@@ -121,12 +121,18 @@ namespace ForestBrush.GUI
         {
             bool editVisible = father.ToggleBrushEdit();
             toggleEditButton.normalBgSprite = toggleEditButton.focusedBgSprite = editVisible ? ResourceLoader.SettingsDropboxPressed : ResourceLoader.SettingsDropbox;
+            if (editVisible) father.KeepWithinScreen();
+            UserMod.Settings.BrushEditOpen = editVisible;
+            UserMod.SaveSettings();
         }
 
         private void ToggleOptionsButton_eventClicked(UIComponent component, UIMouseEventParameter eventParam)
         {
             bool optionsVisible = father.ToggleBrushOptions();
             toggleOptionsButton.normalBgSprite = toggleOptionsButton.focusedBgSprite = optionsVisible ? ResourceLoader.OptionsDropboxPressed : ResourceLoader.OptionsDropbox;
+            if (optionsVisible) father.KeepWithinScreen();
+            UserMod.Settings.BrushOptionsOpen = optionsVisible;
+            UserMod.SaveSettings();
         }
 
         internal void UpdateDropDown()

--- a/ForestBrush/GUI/ForestBrushPanel.cs
+++ b/ForestBrush/GUI/ForestBrushPanel.cs
@@ -44,7 +44,6 @@ namespace ForestBrush.GUI
             layoutPanelSpace.zOrder = 4;
 
             LocaleManager.eventLocaleChanged += ForestBrushPanel_eventLocaleChanged;
-
             Hide();
         }
 
@@ -78,6 +77,12 @@ namespace ForestBrush.GUI
             BrushSelectSection?.LoadBrush(brush);
             BrushEditSection?.LoadBrush(brush);
             BrushOptionsSection?.LoadBrush(brush);
+        }
+
+        internal void KeepWithinScreen()
+        {
+            ClampToScreen();
+            if (relativePosition.y + height > Screen.height - 130.0f) relativePosition -= new Vector3(0.0f, 130.0f, 0.0f);
         }
     }
 }

--- a/ForestBrush/GUI/ImageUtil.cs
+++ b/ForestBrush/GUI/ImageUtil.cs
@@ -17,7 +17,7 @@ namespace ForestBrush.GUI
 
             if (m_previewRenderer == null)
             {
-                m_previewRenderer = new GameObject("ForestBrushPreviewRenderer").AddComponent<PreviewRenderer>();
+                m_previewRenderer = ForestBrush.Instance.gameObject.AddComponent<PreviewRenderer>();
                 m_previewRenderer.size = new Vector2(109, 100) * 2f;
             }
 

--- a/ForestBrush/Locale/english.xml
+++ b/ForestBrush/Locale/english.xml
@@ -32,9 +32,12 @@
     <Translation ID="FOREST-BRUSH-OPTIONS-SORTING-ASCENDING" String="Ascending" />
     <Translation ID="FOREST-BRUSH-OPTIONS-SORTING-DESCENDING" String="Descending" />
     <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-LOGIC" String="Search logic" />
-    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-AND" String="Advanced 'AND' (Slow)" />
-    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-OR" String="Advanced 'OR' (Slow)" />
-    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-SIMPLE" String="Simple (Fast)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-AND" String="AND (Match both words)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-OR" String="OR (Match either word)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-SIMPLE" String="Simple (Faster 'Tree-name only' search)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-NEWBRUSH" String="When creating a new brush" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-NEWBRUSH-CLEAR" String="Start with empty brush" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-NEWBRUSH-KEEP" String="Keep trees from last brush" />
     <Translation ID="FOREST-BRUSH-MODAL-WARNING" String="Warning" />
     <Translation ID="FOREST-BRUSH-MODAL-LIMITREACHED-TITLE" String="Tree limit reached" />
     <Translation ID="FOREST-BRUSH-MODAL-LIMITREACHED-MESSAGE-ONE" String="You've reached the 100 tree limit for this brush. Please remove some trees to add more." />

--- a/ForestBrush/Locale/german.xml
+++ b/ForestBrush/Locale/german.xml
@@ -32,9 +32,12 @@
     <Translation ID="FOREST-BRUSH-OPTIONS-SORTING-ASCENDING" String="Ascending" />
     <Translation ID="FOREST-BRUSH-OPTIONS-SORTING-DESCENDING" String="Descending" />
     <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-LOGIC" String="Search logic" />
-    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-AND" String="Advanced 'AND' (Slow)" />
-    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-OR" String="Advanced 'OR' (Slow)" />
-    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-SIMPLE" String="Simple (Fast)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-AND" String="AND (Match both words)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-OR" String="OR (Match either word)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-SIMPLE" String="Simple (Faster Tree name only search)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-NEWBRUSH" String="When creating a new brush" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-NEWBRUSH-CLEAR" String="Start with empty brush" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-NEWBRUSH-KEEP" String="Keep trees from last brush" />
     <Translation ID="FOREST-BRUSH-MODAL-WARNING" String="Warnung" />
     <Translation ID="FOREST-BRUSH-MODAL-LIMITREACHED-TITLE" String="Baum Limit erreicht" />
     <Translation ID="FOREST-BRUSH-MODAL-LIMITREACHED-MESSAGE-ONE" String="Du hast das Limit von 100 Bäumen für diesen Pinsel erreicht. Bitte entferne zunächst Bäume um andere hinzuzufügen." />

--- a/ForestBrush/Locale/russian.xml
+++ b/ForestBrush/Locale/russian.xml
@@ -32,9 +32,12 @@
     <Translation ID="FOREST-BRUSH-OPTIONS-SORTING-ASCENDING" String="Ascending" />
     <Translation ID="FOREST-BRUSH-OPTIONS-SORTING-DESCENDING" String="Descending" />
     <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-LOGIC" String="Search logic" />
-    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-AND" String="Advanced 'AND' (Slow)" />
-    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-OR" String="Advanced 'OR' (Slow)" />
-    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-SIMPLE" String="Simple (Fast)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-AND" String="AND (Match both words)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-OR" String="OR (Match either word)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-SIMPLE" String="Simple (Faster Tree name only search)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-NEWBRUSH" String="When creating a new brush" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-NEWBRUSH-CLEAR" String="Start with empty brush" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-NEWBRUSH-KEEP" String="Keep trees from last brush" />
     <Translation ID="FOREST-BRUSH-MODAL-WARNING" String="Внимание" />
     <Translation ID="FOREST-BRUSH-MODAL-LIMITREACHED-TITLE" String="Достигнут предел деревьев" />
     <Translation ID="FOREST-BRUSH-MODAL-LIMITREACHED-MESSAGE-ONE" String="Вы достигли предела в 100 деревьев для этой кисти. Пожалуйста, удалите некоторые деревья, чтобы добавить ещё." />

--- a/ForestBrush/Locale/spanish.xml
+++ b/ForestBrush/Locale/spanish.xml
@@ -32,9 +32,12 @@
     <Translation ID="FOREST-BRUSH-OPTIONS-SORTING-ASCENDING" String="Ascendente" />
     <Translation ID="FOREST-BRUSH-OPTIONS-SORTING-DESCENDING" String="Descendiente" />
     <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-LOGIC" String="Lógica de búsqueda" />
-    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-AND" String="Avanzada 'AND' (Lenta)" />
-    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-OR" String="Avanzada 'OR' (Lenta)" />
-    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-SIMPLE" String="Simple (Rápida)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-AND" String="AND (Contiene ambos términos)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-OR" String="OR (Contiene cualquier término)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-FILTERING-SIMPLE" String="Simple (Busca rapida solo de los nombres)" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-NEWBRUSH" String="Al crear un nuevo pincel" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-NEWBRUSH-CLEAR" String="Remueve los árboles del pincel anterior" />
+    <Translation ID="FOREST-BRUSH-OPTIONS-NEWBRUSH-KEEP" String="Mantén los árboles del pincel anterior" />
     <Translation ID="FOREST-BRUSH-MODAL-WARNING" String="Advertencia" />
     <Translation ID="FOREST-BRUSH-MODAL-LIMITREACHED-TITLE" String="Limite de árboles alcanzado" />
     <Translation ID="FOREST-BRUSH-MODAL-LIMITREACHED-MESSAGE-ONE" String="Haz alcanzado el limite de 100 arboles por pincel. Porfavor remueve algunos árboles para agregar más." />

--- a/ForestBrush/Persistence/XMLPersistenceService.cs
+++ b/ForestBrush/Persistence/XMLPersistenceService.cs
@@ -16,7 +16,7 @@ namespace ForestBrush.Persistence
             {
                 PanelPosX = settings.PanelPosX,
                 PanelPosY = settings.PanelPosY,
-                AddRemoveTreesToBrushOpen = settings.AddRemoveTreesToBrushOpen,
+                BrushEditOpen = settings.BrushEditOpen,
                 BrushOptionsOpen = settings.BrushOptionsOpen,
                 ShowTreeMeshData = settings.ShowTreeMeshData,
                 Sorting = settings.Sorting,
@@ -24,7 +24,8 @@ namespace ForestBrush.Persistence
                 FilterStyle = settings.FilterStyle,
                 Brushes = settings.Brushes,
                 SelectedBrush = settings.SelectedBrush.Name,
-                ToggleTool = GetXmlInputKey(settings.ToggleTool)
+                ToggleTool = GetXmlInputKey(settings.ToggleTool),
+                KeepTreesInNewBrush = settings.KeepTreesInNewBrush
             };
 
             using (var sw = new StreamWriter(configurationPath))
@@ -47,7 +48,7 @@ namespace ForestBrush.Persistence
                 return new Settings(
                     xmlSettings.PanelPosX,
                     xmlSettings.PanelPosY,
-                    xmlSettings.AddRemoveTreesToBrushOpen,
+                    xmlSettings.BrushEditOpen,
                     xmlSettings.BrushOptionsOpen,
                     xmlSettings.ShowTreeMeshData,
                     xmlSettings.Sorting,
@@ -55,7 +56,8 @@ namespace ForestBrush.Persistence
                     xmlSettings.FilterStyle,
                     xmlSettings.Brushes,
                     xmlSettings.SelectedBrush,
-                    GetSavedInputKey(xmlSettings.ToggleTool)
+                    GetSavedInputKey(xmlSettings.ToggleTool),
+                    xmlSettings.KeepTreesInNewBrush
                 );
             }
             else

--- a/ForestBrush/Persistence/XMLSettings.cs
+++ b/ForestBrush/Persistence/XMLSettings.cs
@@ -10,7 +10,7 @@ namespace ForestBrush.Persistence
 
         public float PanelPosY { get; set; }
 
-        public bool AddRemoveTreesToBrushOpen { get; set; }
+        public bool BrushEditOpen { get; set; }
 
         public bool BrushOptionsOpen { get; set; }
 
@@ -25,6 +25,8 @@ namespace ForestBrush.Persistence
         public List<Brush> Brushes { get; set; }
 
         public string SelectedBrush { get; set; }
+
+        public bool KeepTreesInNewBrush { get; set; }
 
         public XmlInputKey Search { get; set; }
 

--- a/ForestBrush/Settings.cs
+++ b/ForestBrush/Settings.cs
@@ -10,7 +10,7 @@ namespace ForestBrush
         public Settings(
             float panelPosX,
             float panelPosY,
-            bool addRemoveTreesToBrushOpen,
+            bool BrushEditOpen,
             bool BrushOptionsOpen,
             bool ShowTreeMeshData,
             TreeSorting Sorting,
@@ -18,18 +18,20 @@ namespace ForestBrush
             FilterStyle FilterStyle,
             IEnumerable<Brush> forestBrushes,
             string selectedBrush,
-            SavedInputKey toggleTool
+            SavedInputKey toggleTool,
+            bool keepTreesInNewBrush
         )
         {
             this.PanelPosX = panelPosX;
             this.PanelPosY = panelPosY;
-            this.AddRemoveTreesToBrushOpen = addRemoveTreesToBrushOpen;
+            this.BrushEditOpen = BrushEditOpen;
             this.BrushOptionsOpen = BrushOptionsOpen;
             this.ShowTreeMeshData = ShowTreeMeshData;
             this.Sorting = Sorting;
             this.SortingOrder = SortingOrder;
             this.FilterStyle = FilterStyle;
             this.ToggleTool = toggleTool;
+            this.KeepTreesInNewBrush = keepTreesInNewBrush;
 
             this.Brushes = forestBrushes.ToList();
             if (this.Brushes.Count == 0)
@@ -45,7 +47,7 @@ namespace ForestBrush
 
         public float PanelPosY { get; set; }
 
-        public bool AddRemoveTreesToBrushOpen { get; set; }
+        public bool BrushEditOpen { get; set; }
 
         public bool BrushOptionsOpen { get; set; }
 
@@ -63,6 +65,8 @@ namespace ForestBrush
 
         public SavedInputKey ToggleTool { get; set; }
 
+        public bool KeepTreesInNewBrush { get; internal set; }
+
         public static Settings Default()
         {
             var defaultBrush = Brush.Default();
@@ -78,7 +82,8 @@ namespace ForestBrush
                 FilterStyle.AND,
                 Enumerable.Empty<Brush>(),
                 string.Empty,
-                new SavedInputKey("toggleTool", Constants.ModName, SavedInputKey.Encode(KeyCode.B, false, false, true), true)
+                new SavedInputKey("toggleTool", Constants.ModName, SavedInputKey.Encode(KeyCode.B, false, false, true), true),
+                false
             );
         }
 
@@ -126,7 +131,7 @@ namespace ForestBrush
 
             this.PanelPosX = defaultSettings.PanelPosX;
             this.PanelPosY = defaultSettings.PanelPosY;
-            this.AddRemoveTreesToBrushOpen = defaultSettings.AddRemoveTreesToBrushOpen;
+            this.BrushEditOpen = defaultSettings.BrushEditOpen;
             this.BrushOptionsOpen = defaultSettings.BrushOptionsOpen;
             this.ToggleTool = defaultSettings.ToggleTool;
             this.ShowTreeMeshData = defaultSettings.ShowTreeMeshData;

--- a/ForestBrush/Tool.cs
+++ b/ForestBrush/Tool.cs
@@ -111,7 +111,8 @@ namespace ForestBrush
 
                 brush.Name = brushName;
 
-                brush.ReplaceAll(TreeInfos);
+                if (UserMod.Settings.KeepTreesInNewBrush) brush.ReplaceAll(TreeInfos);
+                else RemoveAll();
 
                 Brushes.Add(brush);
 

--- a/ForestBrush/UserMod.cs
+++ b/ForestBrush/UserMod.cs
@@ -24,6 +24,7 @@ namespace ForestBrush
         private OptionsKeyBinding optionKeys;
         private GameObject forestBrushGameObject;
         private UIDropDown searchLogic;
+        private UIDropDown newBrushBehaviour;
 
         public string Name => Constants.ModName;
 
@@ -108,9 +109,12 @@ namespace ForestBrush
 
         void UninstallMod()
         {
+            try { harmony.UnpatchAll(harmonyId); }
+            catch (Exception) { }
+            finally { harmony = null; }
+
             ForestBrush.Instance.CleanUp();
-            harmony.UnpatchAll(harmonyId);
-            harmony = null;
+
             if (IsMap || IsTheme)
             {
                 if(Resources.ResourceLoader.Atlas != null) UnityEngine.Resources.UnloadAsset(Resources.ResourceLoader.Atlas);
@@ -165,16 +169,32 @@ namespace ForestBrush
                 searchLogic = (UIDropDown)group.AddDropdown(Translation.Instance.GetTranslation("FOREST-BRUSH-OPTIONS-FILTERING-LOGIC"),
                                   new string[]
                                   {
-                                      Translation.Instance.GetTranslation("FOREST-BRUSH-OPTIONS-FILTERING-SIMPLE"),
                                       Translation.Instance.GetTranslation("FOREST-BRUSH-OPTIONS-FILTERING-AND"),
-                                      Translation.Instance.GetTranslation("FOREST-BRUSH-OPTIONS-FILTERING-OR")
+                                      Translation.Instance.GetTranslation("FOREST-BRUSH-OPTIONS-FILTERING-OR"),
+                                      Translation.Instance.GetTranslation("FOREST-BRUSH-OPTIONS-FILTERING-SIMPLE")
                                   },
                                   (int)Settings.FilterStyle,
                                   (index) =>
                                   {
                                       Settings.FilterStyle = (FilterStyle)index; SaveSettings();
                                   });
-                searchLogic.width = 325.0f;
+                searchLogic.width = 500.0f;
+
+                group.AddSpace(10);
+
+                newBrushBehaviour = (UIDropDown)group.AddDropdown(Translation.Instance.GetTranslation("FOREST-BRUSH-OPTIONS-NEWBRUSH"),
+                                  new string[]
+                                  {
+                                      Translation.Instance.GetTranslation("FOREST-BRUSH-OPTIONS-NEWBRUSH-CLEAR"),
+                                      Translation.Instance.GetTranslation("FOREST-BRUSH-OPTIONS-NEWBRUSH-KEEP")
+                                  },
+                                  Settings.KeepTreesInNewBrush ? 1 : 0,
+                                  (index) =>
+                                  {
+                                      Settings.KeepTreesInNewBrush = index == 1 ? true : false; SaveSettings();
+                                  });
+                newBrushBehaviour.width = 500.0f;
+
                 group.AddSpace(10);
 
                 group.AddCheckbox(Translation.Instance.GetTranslation("FOREST-BRUSH-OPTIONS-SHOWMESHDATA"), Settings.ShowTreeMeshData, (b) => { Settings.ShowTreeMeshData = b; SaveSettings(); });


### PR DESCRIPTION
Fix: bad tooltip generation code made quicker
Fix: author queries now working properly in all cases
Fix: expanding panel while in lower part of screen no longer
pushes subpanels off-screen/into the main toolbar
Fix(temp): Harmony exception caught and ignored with no user nuisance
Feature: panel sections visibility remembered between sessions Issue #32
Feature: added option to start new brushes with or without previous
brush trees in them Issue #33
Refactored some reflection code for performance.
Changed default delete behaviour to normal vanilla delete, forest brush
delete with hotkey.